### PR TITLE
added manual distance calculation if Google fails

### DIFF
--- a/NashvilleHistory/www/js/controllers/MarkersCtrl.js
+++ b/NashvilleHistory/www/js/controllers/MarkersCtrl.js
@@ -95,16 +95,17 @@ app.controller('MarkersCtrl', function($scope, $state, $cordovaGeolocation, Mark
         })
       )
       .then((data)=>{
+        console.log(data);
         //Adding the distance and duration via car to the AllMarkers array
-        let distanceData = data.map((row)=>{
-          return {
-            distance: parseFloat(row.rows[0].elements[0].distance.text.split(" ")[0]),
-            duration: parseFloat(row.rows[0].elements[0].duration.text.split(" ")[0])
+        let distanceData = data.forEach((row, index)=>{
+          // If Google API returned the data
+          if (row.rows) {
+            AllMarkers[index].distance = parseFloat(row.rows[0].elements[0].distance.text.split(" ")[0]);
+            AllMarkers[index].duration = parseFloat(row.rows[0].elements[0].duration.text.split(" ")[0]);
+          // Else use the manual calculation
+          } else {
+            AllMarkers[index].distance = row;
           }
-        })
-        distanceData.forEach((element, index)=>{
-          AllMarkers[index].distance = element.distance;
-          AllMarkers[index].duration = element.duration;
         })
         sortMarkersByDistance();
       })

--- a/NashvilleHistory/www/js/factories/MarkerCardsFact.js
+++ b/NashvilleHistory/www/js/factories/MarkerCardsFact.js
@@ -45,12 +45,44 @@ app.factory("MarkerCardsFact", ($q, $http, KeyGetter)=>{
     return $q((resolve, reject)=>{
       $http.get(`https://maps.googleapis.com/maps/api/distancematrix/json?units=imperial&origins=${lat},${long}&destinations=${markerLat}%2C${markerLong}&key=${GoogleAppToken}`)
       .success((data)=>{
-        resolve(data);
+        // If Google API errors out, calculate distance manually
+        if (data.error_message) {
+          console.log("using manual distance");
+          let distance = calculateDistanceToMarker(lat, long, markerLat, markerLong);
+          resolve(distance);
+        } else {
+          resolve(data);
+        }
       })
       .error((err)=>{
-        reject(err);
+        console.error(error);
+        reject(error);
       })
     });
+  }
+
+  function calculateDistanceToMarker(lat1, lon1, lat2, lon2){
+    var R = 6371e3; // metres
+    var φ1 = toRadians(lat1);
+    var φ2 = toRadians(lat2);
+    var Δφ = toRadians((lat2-lat1));
+    var Δλ = toRadians((lon2-lon1));
+
+    var a = Math.sin(Δφ/2) * Math.sin(Δφ/2) +
+        Math.cos(φ1) * Math.cos(φ2) *
+        Math.sin(Δλ/2) * Math.sin(Δλ/2);
+    var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+    var d = R * c;
+    return getMiles(d).toPrecision(3);
+  }
+
+  function toRadians(x) {
+    return x * Math.PI / 180;
+  }
+
+  // Converts meters to miles
+  function getMiles(i) {
+   return i*0.000621371192;
   }
 
   return {getHistoricalMarkersInRadius, getArtInPublicPlacesMarkersInRadius, getMetroPublicArtMarkersInRadius, getDistanceToMarker};

--- a/NashvilleHistory/www/js/factories/MarkerCardsFact.js
+++ b/NashvilleHistory/www/js/factories/MarkerCardsFact.js
@@ -73,7 +73,7 @@ app.factory("MarkerCardsFact", ($q, $http, KeyGetter)=>{
         Math.sin(Δλ/2) * Math.sin(Δλ/2);
     var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
     var d = R * c;
-    return getMiles(d).toPrecision(3);
+    return getMiles(d).toPrecision(2);
   }
 
   function toRadians(x) {

--- a/NashvilleHistory/www/js/factories/MarkerCardsFact.js
+++ b/NashvilleHistory/www/js/factories/MarkerCardsFact.js
@@ -61,6 +61,9 @@ app.factory("MarkerCardsFact", ($q, $http, KeyGetter)=>{
     });
   }
 
+  // Haversine formula, source: http://www.movable-type.co.uk/scripts/latlong.html
+  // where  φ is latitude, λ is longitude, R is earth’s radius (mean radius = 6,371km);
+  // note that angles need to be in radians to pass to trig functions
   function calculateDistanceToMarker(lat1, lon1, lat2, lon2){
     var R = 6371e3; // metres
     var φ1 = toRadians(lat1);


### PR DESCRIPTION
## Status
**READY**

## Documentation

[X] I have fully documented features in this PR's code. Please put an `X` in the box to confirm.

[ ] This PR does **NOT** require documentation.

## Description
Catch Google Maps errors in `MarkerCardsFact.getDistanceToMarker()` and use a manual calculation instead.

## Resolves Issue Number
Resolves #35 

## Deploy Notes

```sh
git pull --prune
git checkout kraatz-manual-distance
ionic serve --lab
```

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. If we've hit our API call limit for the day, make sure we still get distances back.

## Impacted Files in Application
List general components of the application that this PR will affect:

* factories/MarkerCardFact.js
* controllers/MarkersCtrl.js

